### PR TITLE
fix: Docker compatibility issues with Gradio and ElevenLabs API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,10 @@
 python-dotenv
-gradio_client==1.5.4
-gradio==5.12.0
+# huggingface_hub 1.x removed HfFolder class that Gradio 4.x requires
+huggingface_hub<1.0.0
+# Gradio 5.x has localhost accessibility check that fails in Docker containers
+# Using stable 4.19.0 which works reliably in containerized environments
+gradio_client==0.10.0
+gradio==4.19.0
 openai==1.37.0
 httpx==0.27.2
 tiktoken

--- a/shortGPT/api_utils/eleven_api.py
+++ b/shortGPT/api_utils/eleven_api.py
@@ -16,8 +16,18 @@ class ElevenLabsAPI:
         headers = {'accept': 'application/json'}
         if self.api_key:
             headers['xi-api-key'] = self.api_key
-        response = requests.get(url, headers=headers)
-        self.voices = {voice['name']: voice['voice_id'] for voice in response.json()['voices']}
+        try:
+            response = requests.get(url, headers=headers)
+            data = response.json()
+            if 'voices' in data:
+                self.voices = {voice['name']: voice['voice_id'] for voice in data['voices']}
+            else:
+                # API returned an error (e.g., invalid key)
+                print(f"ElevenLabs API error: {data}")
+                self.voices = {}
+        except Exception as e:
+            print(f"Error fetching ElevenLabs voices: {e}")
+            self.voices = {}
         return self.voices
 
     def get_remaining_characters(self):


### PR DESCRIPTION

Proposed changes
This PR fixes three critical issues that prevent ShortGPT from starting in Docker containers:

🐛 Issue 1: Gradio 5.x Localhost Check Fails
Error: ValueError: When localhost is not accessible, a shareable link must be created Cause: Gradio 5.12.0 performs a localhost accessibility check that fails inside Docker containers. Fix: Downgraded to Gradio 4.19.0 which doesn't have this check.

🐛 Issue 2: HuggingFace Hub Import Error
Error: ImportError: cannot import name 'HfFolder' from 'huggingface_hub' Cause: huggingface_hub 1.0+ removed the HfFolder class that Gradio 4.x imports. Fix: Pinned huggingface_hub<1.0.0.

🐛 Issue 3: ElevenLabs API Crash
Error: KeyError: 'voices' Cause: Code crashes when ElevenLabs API key is invalid/missing. Fix: Added try/except error handling - app now gracefully continues with Edge TTS.

Tested on:
Windows 11 with Docker Desktop
python:3.10-slim-bullseye image
✅ UI loads at http://localhost:31415/
✅ All tabs functional
Types of changes
 Bugfix (non-breaking change which fixes an issue) 🐛

