### PR TITLE
feat: add MiniMax as LLM and TTS provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ ShortGPT utilizes the following technologies to power its functionality:
 
 - **Openai**: Openai is used for automating the entire process, including generating scripts and prompts for LLM automated editing processes.
 
+- **MiniMax**: [MiniMax](https://platform.minimax.io/) is supported as an alternative LLM provider (MiniMax-M2.7) via OpenAI-compatible API, and as a high-quality TTS engine (speech-2.8-hd) with 12 built-in voices.
+
 - **ElevenLabs**: ElevenLabs is used for voice synthesis, supporting multiple languages for voiceover creation.
 
 - **EdgeTTS**: Microsoft's FREE EdgeTTS is used for voice synthesis, supporting way many more language than ElevenLabs currently.

--- a/gui/asset_components.py
+++ b/gui/asset_components.py
@@ -6,6 +6,7 @@ import subprocess
 import gradio as gr
 
 from shortGPT.api_utils.eleven_api import ElevenLabsAPI
+from shortGPT.audio.minimax_voice_module import MINIMAX_TTS_VOICES
 from shortGPT.config.api_db import ApiKeyManager
 from shortGPT.config.asset_db import AssetDatabase
 
@@ -13,6 +14,7 @@ from shortGPT.config.asset_db import AssetDatabase
 class AssetComponentsUtils:
     EDGE_TTS = "Free EdgeTTS (lower quality)"
     ELEVEN_TTS = "ElevenLabs(Very High Quality)"
+    MINIMAX_TTS = "MiniMax TTS (High Quality)"
 
 
     instance_background_video_checkbox = None
@@ -72,6 +74,10 @@ class AssetComponentsUtils:
         return cls.instance_background_music_checkbox
 
     @classmethod
+    def getMiniMaxVoices(cls):
+        return list(MINIMAX_TTS_VOICES.keys())
+
+    @classmethod
     def voiceChoice(cls, provider: str = None):
         if provider == None:
             provider = cls.ELEVEN_TTS
@@ -81,6 +87,13 @@ class AssetComponentsUtils:
                     cls.getElevenlabsVoices(),
                     label="Elevenlabs voice",
                     value="Chris",
+                    interactive=True,
+                )
+            elif provider == cls.MINIMAX_TTS:
+                cls.instance_voiceChoice[provider] = gr.Radio(
+                    cls.getMiniMaxVoices(),
+                    label="MiniMax voice",
+                    value="English_Graceful_Lady",
                     interactive=True,
                 )
         return cls.instance_voiceChoice[provider]
@@ -95,6 +108,13 @@ class AssetComponentsUtils:
                     cls.getElevenlabsVoices(),
                     label="Elevenlabs voice",
                     value="Chris",
+                    interactive=True,
+                )
+            elif provider == cls.MINIMAX_TTS:
+                cls.instance_voiceChoiceTranslation[provider] = gr.Radio(
+                    cls.getMiniMaxVoices(),
+                    label="MiniMax voice",
+                    value="English_Graceful_Lady",
                     interactive=True,
                 )
         return cls.instance_voiceChoiceTranslation[provider]

--- a/gui/ui_tab_config.py
+++ b/gui/ui_tab_config.py
@@ -31,12 +31,14 @@ class ConfigUI(AbstractComponentUI):
                 raise gr.Error(e.args[0])
         return remaining_chars
 
-    def save_keys(self, openai_key, eleven_key, pexels_key, gemini_key):
+    def save_keys(self, openai_key, eleven_key, pexels_key, gemini_key, minimax_key):
         '''Save the keys in the database'''
         if (self.api_key_manager.get_api_key("OPENAI_API_KEY") != openai_key):
             self.api_key_manager.set_api_key("OPENAI_API_KEY", openai_key)
         if (self.api_key_manager.get_api_key("PEXELS_API_KEY") != pexels_key):
             self.api_key_manager.set_api_key("PEXELS_API_KEY", pexels_key)
+        if (self.api_key_manager.get_api_key("MINIMAX_API_KEY") != minimax_key):
+            self.api_key_manager.set_api_key("MINIMAX_API_KEY", minimax_key)
         if (self.api_key_manager.get_api_key('ELEVENLABS_API_KEY') != eleven_key):
             self.api_key_manager.set_api_key("ELEVENLABS_API_KEY", eleven_key)
             new_eleven_voices = AssetComponentsUtils.getElevenlabsVoices()
@@ -44,6 +46,7 @@ class ConfigUI(AbstractComponentUI):
                 gr.update(value=eleven_key),\
                 gr.update(value=pexels_key),\
                 gr.update(value=gemini_key),\
+                gr.update(value=minimax_key),\
                 gr.update(choices=new_eleven_voices),\
                 gr.update(choices=new_eleven_voices)
         if (self.api_key_manager.get_api_key("GEMINI_API_KEY") != gemini_key):
@@ -53,6 +56,7 @@ class ConfigUI(AbstractComponentUI):
             gr.update(value=eleven_key),\
             gr.update(value=pexels_key),\
             gr.update(value=gemini_key),\
+            gr.update(value=minimax_key),\
             gr.update(visible=True),\
             gr.update(visible=True)
 
@@ -92,10 +96,14 @@ class ConfigUI(AbstractComponentUI):
                         gemini_textbox = gr.Textbox(value=self.api_key_manager.get_api_key("GEMINI_API_KEY"), label=f"GEMINI API KEY", show_label=True, interactive=True, show_copy_button=True, type="password", scale=40)
                         show_gemini_key = gr.Button("Show", size="sm", scale=1)
                         show_gemini_key.click(self.on_show, [show_gemini_key], [gemini_textbox, show_gemini_key])
+                    with gr.Row():
+                        minimax_textbox = gr.Textbox(value=self.api_key_manager.get_api_key("MINIMAX_API_KEY"), label=f"MINIMAX API KEY", show_label=True, interactive=True, show_copy_button=True, type="password", scale=40)
+                        show_minimax_key = gr.Button("Show", size="sm", scale=1)
+                        show_minimax_key.click(self.on_show, [show_minimax_key], [minimax_textbox, show_minimax_key])
 
                     save_button = gr.Button("save", size="sm", scale=1)
                     save_button.click(self.verify_eleven_key, [eleven_labs_textbox, eleven_characters_remaining], [eleven_characters_remaining]).success(
-                        self.save_keys, [openai_textbox, eleven_labs_textbox, pexels_textbox, gemini_textbox], [openai_textbox, eleven_labs_textbox, pexels_textbox, gemini_textbox, AssetComponentsUtils.voiceChoice(), AssetComponentsUtils.voiceChoiceTranslation()])
+                        self.save_keys, [openai_textbox, eleven_labs_textbox, pexels_textbox, gemini_textbox, minimax_textbox], [openai_textbox, eleven_labs_textbox, pexels_textbox, gemini_textbox, minimax_textbox, AssetComponentsUtils.voiceChoice(), AssetComponentsUtils.voiceChoiceTranslation()])
                     save_button.click(lambda _: gr.update(value="Keys Saved !"), [], [save_button])
                     save_button.click(self.back_to_normal, [], [save_button])
         return config_ui

--- a/gui/ui_tab_short_automation.py
+++ b/gui/ui_tab_short_automation.py
@@ -9,6 +9,7 @@ from gui.ui_abstract_component import AbstractComponentUI
 from gui.ui_components_html import GradioComponentsHTML
 from shortGPT.audio.edge_voice_module import EdgeTTSVoiceModule
 from shortGPT.audio.eleven_voice_module import ElevenLabsVoiceModule
+from shortGPT.audio.minimax_voice_module import MiniMaxVoiceModule
 from shortGPT.config.api_db import ApiKeyManager
 from shortGPT.config.languages import (EDGE_TTS_VOICENAME_MAPPING,
                                        ELEVEN_SUPPORTED_LANGUAGES,
@@ -30,17 +31,19 @@ class ShortAutomationUI(AbstractComponentUI):
                 short_type = gr.Radio(["Reddit Story shorts", "Historical Facts shorts", "Scientific Facts shorts", "Custom Facts shorts"], label="Type of shorts generated", value="Reddit Story shorts", interactive=True)
                 facts_subject = gr.Textbox(label="Write a subject for your facts (example: Football facts)", interactive=True, visible=False)
                 short_type.change(lambda x: gr.update(visible=x == "Custom Facts shorts"), [short_type], [facts_subject])
-                tts_engine = gr.Radio([AssetComponentsUtils.ELEVEN_TTS, AssetComponentsUtils.EDGE_TTS], label="Text to speech engine", value=AssetComponentsUtils.EDGE_TTS, interactive=True)
+                tts_engine = gr.Radio([AssetComponentsUtils.ELEVEN_TTS, AssetComponentsUtils.EDGE_TTS, AssetComponentsUtils.MINIMAX_TTS], label="Text to speech engine", value=AssetComponentsUtils.EDGE_TTS, interactive=True)
                 self.tts_engine = tts_engine.value
                 with gr.Column(visible=False) as eleven_tts:
                     language_eleven = gr.Radio([lang.value for lang in ELEVEN_SUPPORTED_LANGUAGES], label="Language", value="English", interactive=True)
                     voice_eleven = AssetComponentsUtils.voiceChoice(provider=AssetComponentsUtils.ELEVEN_TTS)
                 with gr.Column(visible=True) as edge_tts:
                     language_edge = gr.Dropdown([lang.value.upper() for lang in Language], label="Language", value="ENGLISH", interactive=True)
+                with gr.Column(visible=False) as minimax_tts:
+                    voice_minimax = AssetComponentsUtils.voiceChoice(provider=AssetComponentsUtils.MINIMAX_TTS)
                 def tts_engine_change(x):
                     self.tts_engine = x
-                    return gr.update(visible=x == AssetComponentsUtils.ELEVEN_TTS), gr.update(visible=x == AssetComponentsUtils.EDGE_TTS)
-                tts_engine.change(tts_engine_change, tts_engine, [eleven_tts, edge_tts])
+                    return gr.update(visible=x == AssetComponentsUtils.ELEVEN_TTS), gr.update(visible=x == AssetComponentsUtils.EDGE_TTS), gr.update(visible=x == AssetComponentsUtils.MINIMAX_TTS)
+                tts_engine.change(tts_engine_change, tts_engine, [eleven_tts, edge_tts, minimax_tts])
 
                 useImages = gr.Checkbox(label="Use images", value=True)
                 numImages = gr.Radio([5, 10, 25], value=10, label="Number of images per short", visible=True, interactive=True)
@@ -72,11 +75,12 @@ class ShortAutomationUI(AbstractComponentUI):
                 AssetComponentsUtils.background_music_checkbox(),
                 facts_subject,
                 voice_eleven,
+                voice_minimax,
             ], outputs=[output, video_folder, generation_error])
         self.short_automation = short_automation
         return self.short_automation
 
-    def create_short(self, numShorts, short_type, tts_engine, language_eleven, language_edge, numImages, watermark, background_video_list, background_music_list, facts_subject, voice_eleven, progress=gr.Progress()):
+    def create_short(self, numShorts, short_type, tts_engine, language_eleven, language_edge, numImages, watermark, background_video_list, background_music_list, facts_subject, voice_eleven, voice_minimax, progress=gr.Progress()):
         '''Creates a short'''
 
         try:
@@ -87,6 +91,9 @@ class ShortAutomationUI(AbstractComponentUI):
             if tts_engine == AssetComponentsUtils.ELEVEN_TTS:
                 language = Language(language_eleven.lower().capitalize())
                 voice_module = ElevenLabsVoiceModule(ApiKeyManager.get_api_key('ELEVENLABS_API_KEY'), voice_eleven, checkElevenCredits=True)
+            elif tts_engine == AssetComponentsUtils.MINIMAX_TTS:
+                language = Language.ENGLISH
+                voice_module = MiniMaxVoiceModule(ApiKeyManager.get_api_key('MINIMAX_API_KEY'), voice_id=voice_minimax or 'English_Graceful_Lady')
             elif tts_engine == AssetComponentsUtils.EDGE_TTS:
                 language = Language(language_edge.lower().capitalize())
                 voice_module = EdgeTTSVoiceModule(EDGE_TTS_VOICENAME_MAPPING[language]['male'])
@@ -145,11 +152,14 @@ class ShortAutomationUI(AbstractComponentUI):
 
         openai_key = ApiKeyManager.get_api_key("OPENAI_API_KEY")
         gemini_key = ApiKeyManager.get_api_key("GEMINI_API_KEY")
-        if not openai_key and not gemini_key:
-            raise gr.Error("GEMINI OR OPENAI API key is missing. Please go to the config tab and enter the API key.")
+        minimax_key = ApiKeyManager.get_api_key("MINIMAX_API_KEY")
+        if not openai_key and not gemini_key and not minimax_key:
+            raise gr.Error("GEMINI, OPENAI, or MINIMAX API key is missing. Please go to the config tab and enter an API key.")
         eleven_labs_key = ApiKeyManager.get_api_key("ELEVENLABS_API_KEY")
         if self.tts_engine == AssetComponentsUtils.ELEVEN_TTS and not eleven_labs_key:
             raise gr.Error("ELEVENLABS_API_KEY API key is missing. Please go to the config tab and enter the API key.")
+        if self.tts_engine == AssetComponentsUtils.MINIMAX_TTS and not minimax_key:
+            raise gr.Error("MINIMAX_API_KEY is missing. Please go to the config tab and enter the API key.")
         return gr.update(visible=False)
 
     def create_short_engine(self, short_type, voice_module, language, numImages, watermark, background_video, background_music, facts_subject):

--- a/gui/ui_tab_video_automation.py
+++ b/gui/ui_tab_video_automation.py
@@ -9,6 +9,7 @@ from gui.ui_abstract_component import AbstractComponentUI
 from gui.ui_components_html import GradioComponentsHTML
 from shortGPT.audio.edge_voice_module import EdgeTTSVoiceModule
 from shortGPT.audio.eleven_voice_module import ElevenLabsVoiceModule
+from shortGPT.audio.minimax_voice_module import MiniMaxVoiceModule
 from shortGPT.config.api_db import ApiKeyManager
 from shortGPT.config.languages import (EDGE_TTS_VOICENAME_MAPPING,
                                         ELEVEN_SUPPORTED_LANGUAGES,
@@ -50,8 +51,9 @@ class VideoAutomationUI(AbstractComponentUI):
     def is_key_missing(self):
         openai_key = ApiKeyManager.get_api_key("OPENAI_API_KEY")
         gemini_key = ApiKeyManager.get_api_key("GEMINI_API_KEY")
-        if not openai_key and not gemini_key:
-            return "Your Genmini or OpenAI key is missing. Please go to the config tab and enter the API key."
+        minimax_key = ApiKeyManager.get_api_key("MINIMAX_API_KEY")
+        if not openai_key and not gemini_key and not minimax_key:
+            return "Your Gemini, OpenAI, or MiniMax key is missing. Please go to the config tab and enter an API key."
 
         pexels_api_key = ApiKeyManager.get_api_key("PEXELS_API_KEY")
         if not pexels_api_key:
@@ -95,7 +97,7 @@ class VideoAutomationUI(AbstractComponentUI):
                 else:
                     self.isVertical = "vertical" in message.lower() or "short" in message.lower()
                     self.state = Chatstate.ASK_VOICE_MODULE
-                    bot_message = "Which voice module do you want to use? Please type 'ElevenLabs' for high quality, 'EdgeTTS' for free medium quality voice."
+                    bot_message = "Which voice module do you want to use? Please type 'ElevenLabs' for high quality, 'MiniMax' for high quality TTS, or 'EdgeTTS' for free medium quality voice."
             elif self.state == Chatstate.ASK_VOICE_MODULE:
                 if "elevenlabs" in message.lower():
                     eleven_labs_key = ApiKeyManager.get_api_key("ELEVENLABS_API_KEY")
@@ -104,11 +106,18 @@ class VideoAutomationUI(AbstractComponentUI):
                         return
                     self.voice_module = ElevenLabsVoiceModule
                     language_choices = [lang.value for lang in ELEVEN_SUPPORTED_LANGUAGES]
+                elif "minimax" in message.lower():
+                    minimax_key = ApiKeyManager.get_api_key("MINIMAX_API_KEY")
+                    if not minimax_key:
+                        bot_message = "Your MINIMAX_API_KEY is missing. Please go to the config tab and enter the API key."
+                        return
+                    self.voice_module = MiniMaxVoiceModule
+                    language_choices = ["English"]
                 elif "edgetts" in message.lower():
                     self.voice_module = EdgeTTSVoiceModule
                     language_choices = [lang.value for lang in Language]
                 else:
-                    bot_message = "Invalid voice module. Please type 'ElevenLabs' or 'EdgeTTS'."
+                    bot_message = "Invalid voice module. Please type 'ElevenLabs', 'MiniMax', or 'EdgeTTS'."
                     return
                 self.state = Chatstate.ASK_LANGUAGE
                 bot_message = f"🌐What language will be used in the video?🌐 Choose from one of these ({', '.join(language_choices)})"
@@ -117,6 +126,8 @@ class VideoAutomationUI(AbstractComponentUI):
                 self.language = self.language if self.language else Language.ENGLISH
                 if self.voice_module == ElevenLabsVoiceModule:
                     self.voice_module = ElevenLabsVoiceModule(ApiKeyManager.get_api_key('ELEVENLABS_API_KEY'), "Chris", checkElevenCredits=True)
+                elif self.voice_module == MiniMaxVoiceModule:
+                    self.voice_module = MiniMaxVoiceModule(ApiKeyManager.get_api_key('MINIMAX_API_KEY'), voice_id='English_Graceful_Lady')
                 elif self.voice_module == EdgeTTSVoiceModule:
                     self.voice_module = EdgeTTSVoiceModule(EDGE_TTS_VOICENAME_MAPPING[self.language]['male'])
                 self.state = Chatstate.ASK_DESCRIPTION

--- a/gui/ui_tab_video_translation.py
+++ b/gui/ui_tab_video_translation.py
@@ -9,6 +9,7 @@ from gui.ui_abstract_component import AbstractComponentUI
 from gui.ui_components_html import GradioComponentsHTML
 from shortGPT.audio.edge_voice_module import EdgeTTSVoiceModule
 from shortGPT.audio.eleven_voice_module import ElevenLabsVoiceModule
+from shortGPT.audio.minimax_voice_module import MiniMaxVoiceModule
 from shortGPT.config.api_db import ApiKeyManager
 from shortGPT.config.languages import (EDGE_TTS_VOICENAME_MAPPING,
                                        ELEVEN_SUPPORTED_LANGUAGES,
@@ -32,14 +33,16 @@ class VideoTranslationUI(AbstractComponentUI):
                 video_path = gr.Video(sources="upload", interactive=True, width=533.33, height=300, visible=False)
                 yt_link = gr.Textbox(label="Youtube link (https://youtube.com/xyz): ", interactive=True, visible=False)
                 videoType.change(lambda x: (gr.update(visible=x == "Video file"), gr.update(visible=x == "Youtube link")), [videoType], [video_path, yt_link])
-                tts_engine = gr.Radio([AssetComponentsUtils.ELEVEN_TTS, AssetComponentsUtils.EDGE_TTS], label="Text to speech engine", value=AssetComponentsUtils.EDGE_TTS, interactive=True)
+                tts_engine = gr.Radio([AssetComponentsUtils.ELEVEN_TTS, AssetComponentsUtils.EDGE_TTS, AssetComponentsUtils.MINIMAX_TTS], label="Text to speech engine", value=AssetComponentsUtils.EDGE_TTS, interactive=True)
                 with gr.Column(visible=False) as eleven_tts:
                     language_eleven = gr.CheckboxGroup(self.eleven_language_choices, label="Language", value="ENGLISH", interactive=True)
                     voice_eleven = AssetComponentsUtils.voiceChoiceTranslation(provider=AssetComponentsUtils.ELEVEN_TTS)
                 with gr.Column(visible=True) as edge_tts:
                     language_edge = gr.CheckboxGroup([lang.value.upper() for lang in Language], label="Language", value="ENGLISH", interactive=True)
-               
-                tts_engine.change(lambda x: (gr.update(visible=x == AssetComponentsUtils.ELEVEN_TTS), gr.update(visible=x == AssetComponentsUtils.EDGE_TTS)), [tts_engine], [eleven_tts, edge_tts])
+                with gr.Column(visible=False) as minimax_tts:
+                    voice_minimax_translation = AssetComponentsUtils.voiceChoiceTranslation(provider=AssetComponentsUtils.MINIMAX_TTS)
+
+                tts_engine.change(lambda x: (gr.update(visible=x == AssetComponentsUtils.ELEVEN_TTS), gr.update(visible=x == AssetComponentsUtils.EDGE_TTS), gr.update(visible=x == AssetComponentsUtils.MINIMAX_TTS)), [tts_engine], [eleven_tts, edge_tts, minimax_tts])
 
                 useCaptions = gr.Checkbox(label="Caption video", value=False)
 
@@ -51,14 +54,16 @@ class VideoTranslationUI(AbstractComponentUI):
 
             video_folder.click(lambda _: AssetComponentsUtils.start_file(os.path.abspath("videos/")))
             translateButton.click(self.inspect_create_inputs, inputs=[videoType, video_path, yt_link, tts_engine, language_eleven, language_edge, ], outputs=[generation_error]).success(self.translate_video, inputs=[
-                videoType, yt_link, video_path, tts_engine, language_eleven, language_edge, useCaptions, voice_eleven
+                videoType, yt_link, video_path, tts_engine, language_eleven, language_edge, useCaptions, voice_eleven, voice_minimax_translation
             ], outputs=[output, video_folder, generation_error])
         self.video_translation_ui = video_translation_ui
         return self.video_translation_ui
 
-    def translate_video(self, videoType, yt_link, video_path, tts_engine, language_eleven, language_edge, use_captions: bool, voice_eleven: str, progress=gr.Progress()) -> str:
+    def translate_video(self, videoType, yt_link, video_path, tts_engine, language_eleven, language_edge, use_captions: bool, voice_eleven: str, voice_minimax: str, progress=gr.Progress()) -> str:
         if tts_engine == AssetComponentsUtils.ELEVEN_TTS:
             languages = [Language(lang.lower().capitalize()) for lang in language_eleven]
+        elif tts_engine == AssetComponentsUtils.MINIMAX_TTS:
+            languages = [Language.ENGLISH]
         elif tts_engine == AssetComponentsUtils.EDGE_TTS:
             languages = [Language(lang.lower().capitalize()) for lang in language_edge]
 
@@ -66,6 +71,8 @@ class VideoTranslationUI(AbstractComponentUI):
             for i, language in enumerate(languages):
                 if tts_engine == AssetComponentsUtils.EDGE_TTS:
                     voice_module = EdgeTTSVoiceModule(EDGE_TTS_VOICENAME_MAPPING[language]['male'])
+                if tts_engine == AssetComponentsUtils.MINIMAX_TTS:
+                    voice_module = MiniMaxVoiceModule(ApiKeyManager.get_api_key('MINIMAX_API_KEY'), voice_id=voice_minimax or 'English_Graceful_Lady')
                 if tts_engine == AssetComponentsUtils.ELEVEN_TTS:
                     voice_module = ElevenLabsVoiceModule(ApiKeyManager.get_api_key('ELEVENLABS_API_KEY'), voice_eleven, checkElevenCredits=True)
                 content_translation_engine = MultiLanguageTranslationEngine(voiceModule=voice_module, src_url=yt_link if videoType == "Youtube link" else video_path, target_language=language, use_captions=use_captions)

--- a/shortGPT/audio/minimax_voice_module.py
+++ b/shortGPT/audio/minimax_voice_module.py
@@ -1,0 +1,81 @@
+import json
+import os
+
+import requests
+
+from shortGPT.audio.voice_module import VoiceModule
+from shortGPT.config.api_db import ApiKeyManager
+
+MINIMAX_TTS_VOICES = {
+    'English_Graceful_Lady': 'Graceful Lady (EN)',
+    'English_Insightful_Speaker': 'Insightful Speaker (EN)',
+    'English_radiant_girl': 'Radiant Girl (EN)',
+    'English_Persuasive_Man': 'Persuasive Man (EN)',
+    'English_Lucky_Robot': 'Lucky Robot (EN)',
+    'Wise_Woman': 'Wise Woman',
+    'cute_boy': 'Cute Boy',
+    'lovely_girl': 'Lovely Girl',
+    'Friendly_Person': 'Friendly Person',
+    'Inspirational_girl': 'Inspirational Girl',
+    'Deep_Voice_Man': 'Deep Voice Man',
+    'sweet_girl': 'Sweet Girl',
+}
+
+
+class MiniMaxVoiceModule(VoiceModule):
+    def __init__(self, api_key, voice_id='English_Graceful_Lady', model='speech-2.8-hd'):
+        self.api_key = api_key
+        self.voice_id = voice_id
+        self.model = model
+        self.base_url = 'https://api.minimax.io'
+        super().__init__()
+
+    def update_usage(self):
+        return None
+
+    def get_remaining_characters(self):
+        return 999999999999
+
+    def generate_voice(self, text, outputfile):
+        url = f'{self.base_url}/v1/t2a_v2'
+        headers = {
+            'Content-Type': 'application/json',
+            'Authorization': f'Bearer {self.api_key}',
+        }
+        payload = {
+            'model': self.model,
+            'text': text,
+            'stream': False,
+            'voice_setting': {
+                'voice_id': self.voice_id,
+                'speed': 1,
+                'vol': 1,
+                'pitch': 0,
+            },
+            'audio_setting': {
+                'sample_rate': 32000,
+                'bitrate': 128000,
+                'format': 'mp3',
+                'channel': 1,
+            },
+        }
+
+        response = requests.post(url, headers=headers, data=json.dumps(payload))
+
+        if response.status_code != 200:
+            raise Exception(f'MiniMax TTS error: {response.status_code} {response.text}')
+
+        result = response.json()
+        if result.get('base_resp', {}).get('status_code', -1) != 0:
+            status_msg = result.get('base_resp', {}).get('status_msg', 'Unknown error')
+            raise Exception(f'MiniMax TTS error: {status_msg}')
+
+        hex_audio = result.get('data', {}).get('audio')
+        if not hex_audio:
+            raise Exception('MiniMax TTS: no audio data in response')
+
+        audio_bytes = bytes.fromhex(hex_audio)
+        with open(outputfile, 'wb') as f:
+            f.write(audio_bytes)
+
+        return outputfile

--- a/shortGPT/config/api_db.py
+++ b/shortGPT/config/api_db.py
@@ -6,6 +6,7 @@ load_dotenv('./.env')
 class ApiProvider(enum.Enum):
     OPENAI = "OPENAI_API_KEY"
     GEMINI = "GEMINI_API_KEY"
+    MINIMAX = "MINIMAX_API_KEY"
     ELEVEN_LABS = "ELEVENLABS_API_KEY"
     PEXELS = "PEXELS_API_KEY"
 

--- a/shortGPT/gpt/gpt_utils.py
+++ b/shortGPT/gpt/gpt_utils.py
@@ -16,16 +16,12 @@ def num_tokens_from_messages(texts, model="gpt-4o-mini"):
         encoding = tiktoken.encoding_for_model(model)
     except KeyError:
         encoding = tiktoken.get_encoding("cl100k_base")
-    if model == "gpt-4o-mini":  # note: future models may deviate from this
-        if isinstance(texts, str):
-            texts = [texts]
-        score = 0
-        for text in texts:
-            score += 4 + len(encoding.encode(text))
-        return score
-    else:
-        raise NotImplementedError(f"""num_tokens_from_messages() is not presently implemented for model {model}.
-        See https://github.com/openai/openai-python/blob/main/chatml.md for information""")
+    if isinstance(texts, str):
+        texts = [texts]
+    score = 0
+    for text in texts:
+        score += 4 + len(encoding.encode(text))
+    return score
 
 
 def extract_biggest_json(string):
@@ -70,19 +66,28 @@ def open_file(filepath):
 from openai import OpenAI
 
 def llm_completion(chat_prompt="", system="", temp=0.7, max_tokens=2000, remove_nl=True, conversation=None):
-    openai_key= ApiKeyManager.get_api_key("OPENAI_API_KEY")
+    openai_key = ApiKeyManager.get_api_key("OPENAI_API_KEY")
     gemini_key = ApiKeyManager.get_api_key("GEMINI_API_KEY")
+    minimax_key = ApiKeyManager.get_api_key("MINIMAX_API_KEY")
     if gemini_key:
-        client = OpenAI( 
+        client = OpenAI(
             api_key=gemini_key,
             base_url="https://generativelanguage.googleapis.com/v1beta/openai/"
         )
-        model="gemini-2.0-flash-lite-preview-02-05"
+        model = "gemini-2.0-flash-lite-preview-02-05"
+    elif minimax_key:
+        client = OpenAI(
+            api_key=minimax_key,
+            base_url="https://api.minimax.io/v1"
+        )
+        model = "MiniMax-M2.7"
+        # MiniMax requires temperature in (0.0, 1.0]
+        temp = max(0.01, min(temp, 1.0))
     elif openai_key:
-        client = OpenAI( api_key=openai_key)
-        model="gpt-4o-mini"
+        client = OpenAI(api_key=openai_key)
+        model = "gpt-4o-mini"
     else:
-        raise Exception("No OpenAI or Gemini API Key found for LLM request")
+        raise Exception("No OpenAI, Gemini, or MiniMax API Key found for LLM request")
     max_retry = 5
     retry = 0
     error = ""

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -1,0 +1,133 @@
+"""Integration tests for MiniMax LLM and TTS providers.
+
+These tests require a valid MINIMAX_API_KEY environment variable.
+They are skipped automatically when the key is not available.
+"""
+
+import os
+import tempfile
+
+import pytest
+
+MINIMAX_API_KEY = os.environ.get('MINIMAX_API_KEY', '')
+skip_no_key = pytest.mark.skipif(not MINIMAX_API_KEY, reason='MINIMAX_API_KEY not set')
+
+
+@skip_no_key
+class TestMiniMaxLLMIntegration:
+    """Integration tests for MiniMax LLM via OpenAI-compatible API."""
+
+    def test_basic_chat_completion(self):
+        """Should complete a basic chat request using MiniMax API."""
+        from openai import OpenAI
+
+        client = OpenAI(
+            api_key=MINIMAX_API_KEY,
+            base_url='https://api.minimax.io/v1',
+        )
+        response = client.chat.completions.create(
+            model='MiniMax-M2.7',
+            messages=[{'role': 'user', 'content': 'Say "test passed" and nothing else.'}],
+            max_tokens=20,
+            temperature=1.0,
+        )
+        assert response.choices[0].message.content
+        assert len(response.choices[0].message.content.strip()) > 0
+
+    def test_chat_completion_with_system_message(self):
+        """Should handle system + user messages."""
+        from openai import OpenAI
+
+        client = OpenAI(
+            api_key=MINIMAX_API_KEY,
+            base_url='https://api.minimax.io/v1',
+        )
+        response = client.chat.completions.create(
+            model='MiniMax-M2.7',
+            messages=[
+                {'role': 'system', 'content': 'You are a helpful assistant. Reply with exactly one word.'},
+                {'role': 'user', 'content': 'What color is the sky?'},
+            ],
+            max_tokens=10,
+            temperature=1.0,
+        )
+        assert response.choices[0].message.content
+        assert len(response.choices[0].message.content.strip()) > 0
+
+    def test_streaming_chat_completion(self):
+        """Should handle streaming responses."""
+        from openai import OpenAI
+
+        client = OpenAI(
+            api_key=MINIMAX_API_KEY,
+            base_url='https://api.minimax.io/v1',
+        )
+        stream = client.chat.completions.create(
+            model='MiniMax-M2.7',
+            messages=[{'role': 'user', 'content': 'Count from 1 to 3.'}],
+            max_tokens=30,
+            temperature=1.0,
+            stream=True,
+        )
+        chunks = []
+        for chunk in stream:
+            if chunk.choices and chunk.choices[0].delta.content:
+                chunks.append(chunk.choices[0].delta.content)
+        assert len(chunks) > 0
+
+
+@skip_no_key
+class TestMiniMaxTTSIntegration:
+    """Integration tests for MiniMax TTS voice module."""
+
+    def test_generate_voice_produces_audio_file(self):
+        """Should generate a valid MP3 audio file."""
+        from shortGPT.audio.minimax_voice_module import MiniMaxVoiceModule
+
+        module = MiniMaxVoiceModule(api_key=MINIMAX_API_KEY)
+        with tempfile.NamedTemporaryFile(suffix='.mp3', delete=False) as f:
+            output_file = f.name
+
+        try:
+            result = module.generate_voice('Hello, this is a test of MiniMax TTS.', output_file)
+            assert result == output_file
+            assert os.path.exists(output_file)
+            file_size = os.path.getsize(output_file)
+            assert file_size > 100, f'Audio file too small: {file_size} bytes'
+        finally:
+            if os.path.exists(output_file):
+                os.unlink(output_file)
+
+    def test_generate_voice_with_different_voice(self):
+        """Should generate audio with a different voice ID."""
+        from shortGPT.audio.minimax_voice_module import MiniMaxVoiceModule
+
+        module = MiniMaxVoiceModule(
+            api_key=MINIMAX_API_KEY,
+            voice_id='English_Persuasive_Man',
+        )
+        with tempfile.NamedTemporaryFile(suffix='.mp3', delete=False) as f:
+            output_file = f.name
+
+        try:
+            result = module.generate_voice('Testing voice module.', output_file)
+            assert result == output_file
+            assert os.path.getsize(output_file) > 100
+        finally:
+            if os.path.exists(output_file):
+                os.unlink(output_file)
+
+    def test_generate_voice_invalid_key_raises(self):
+        """Should raise exception with invalid API key."""
+        from shortGPT.audio.minimax_voice_module import MiniMaxVoiceModule
+
+        module = MiniMaxVoiceModule(api_key='invalid-key-12345')
+        with tempfile.NamedTemporaryFile(suffix='.mp3', delete=False) as f:
+            output_file = f.name
+
+        try:
+            with pytest.raises(Exception):
+                module.generate_voice('Hello', output_file)
+        finally:
+            if os.path.exists(output_file):
+                os.unlink(output_file)

--- a/tests/test_minimax_llm.py
+++ b/tests/test_minimax_llm.py
@@ -1,0 +1,176 @@
+"""Unit tests for MiniMax LLM provider integration in gpt_utils."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestMiniMaxLLMProvider:
+    """Tests for MiniMax LLM integration in gpt_utils.llm_completion."""
+
+    @patch('shortGPT.gpt.gpt_utils.ApiKeyManager')
+    @patch('shortGPT.gpt.gpt_utils.OpenAI')
+    def test_minimax_selected_when_key_present_and_no_gemini(self, mock_openai_cls, mock_key_mgr):
+        """MiniMax should be selected when MINIMAX_API_KEY is set and no Gemini key."""
+        mock_key_mgr.get_api_key.side_effect = lambda key: {
+            'OPENAI_API_KEY': '',
+            'GEMINI_API_KEY': '',
+            'MINIMAX_API_KEY': 'test-minimax-key',
+        }.get(key, '')
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = 'Hello from MiniMax'
+        mock_client.chat.completions.create.return_value = mock_response
+
+        from shortGPT.gpt.gpt_utils import llm_completion
+        result = llm_completion(chat_prompt="Hi", system="You are helpful")
+
+        mock_openai_cls.assert_called_once_with(
+            api_key='test-minimax-key',
+            base_url='https://api.minimax.io/v1'
+        )
+        call_kwargs = mock_client.chat.completions.create.call_args
+        assert call_kwargs[1]['model'] == 'MiniMax-M2.7'
+        assert result == 'Hello from MiniMax'
+
+    @patch('shortGPT.gpt.gpt_utils.ApiKeyManager')
+    @patch('shortGPT.gpt.gpt_utils.OpenAI')
+    def test_gemini_takes_priority_over_minimax(self, mock_openai_cls, mock_key_mgr):
+        """Gemini should be selected over MiniMax when both keys are present."""
+        mock_key_mgr.get_api_key.side_effect = lambda key: {
+            'OPENAI_API_KEY': '',
+            'GEMINI_API_KEY': 'test-gemini-key',
+            'MINIMAX_API_KEY': 'test-minimax-key',
+        }.get(key, '')
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = 'Hello from Gemini'
+        mock_client.chat.completions.create.return_value = mock_response
+
+        from shortGPT.gpt.gpt_utils import llm_completion
+        llm_completion(chat_prompt="Hi", system="You are helpful")
+
+        mock_openai_cls.assert_called_once_with(
+            api_key='test-gemini-key',
+            base_url='https://generativelanguage.googleapis.com/v1beta/openai/'
+        )
+
+    @patch('shortGPT.gpt.gpt_utils.ApiKeyManager')
+    @patch('shortGPT.gpt.gpt_utils.OpenAI')
+    def test_minimax_takes_priority_over_openai(self, mock_openai_cls, mock_key_mgr):
+        """MiniMax should be selected over OpenAI when both keys are present (no Gemini)."""
+        mock_key_mgr.get_api_key.side_effect = lambda key: {
+            'OPENAI_API_KEY': 'test-openai-key',
+            'GEMINI_API_KEY': '',
+            'MINIMAX_API_KEY': 'test-minimax-key',
+        }.get(key, '')
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = 'Hello'
+        mock_client.chat.completions.create.return_value = mock_response
+
+        from shortGPT.gpt.gpt_utils import llm_completion
+        llm_completion(chat_prompt="Hi", system="You are helpful")
+
+        mock_openai_cls.assert_called_once_with(
+            api_key='test-minimax-key',
+            base_url='https://api.minimax.io/v1'
+        )
+
+    @patch('shortGPT.gpt.gpt_utils.ApiKeyManager')
+    @patch('shortGPT.gpt.gpt_utils.OpenAI')
+    def test_minimax_temperature_clamping_zero(self, mock_openai_cls, mock_key_mgr):
+        """MiniMax should clamp temperature=0 to 0.01."""
+        mock_key_mgr.get_api_key.side_effect = lambda key: {
+            'OPENAI_API_KEY': '',
+            'GEMINI_API_KEY': '',
+            'MINIMAX_API_KEY': 'test-key',
+        }.get(key, '')
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = 'OK'
+        mock_client.chat.completions.create.return_value = mock_response
+
+        from shortGPT.gpt.gpt_utils import llm_completion
+        llm_completion(chat_prompt="Hi", system="test", temp=0.0)
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs['temperature'] == 0.01
+
+    @patch('shortGPT.gpt.gpt_utils.ApiKeyManager')
+    @patch('shortGPT.gpt.gpt_utils.OpenAI')
+    def test_minimax_temperature_clamping_high(self, mock_openai_cls, mock_key_mgr):
+        """MiniMax should clamp temperature > 1.0 to 1.0."""
+        mock_key_mgr.get_api_key.side_effect = lambda key: {
+            'OPENAI_API_KEY': '',
+            'GEMINI_API_KEY': '',
+            'MINIMAX_API_KEY': 'test-key',
+        }.get(key, '')
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = 'OK'
+        mock_client.chat.completions.create.return_value = mock_response
+
+        from shortGPT.gpt.gpt_utils import llm_completion
+        llm_completion(chat_prompt="Hi", system="test", temp=1.5)
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs['temperature'] == 1.0
+
+    @patch('shortGPT.gpt.gpt_utils.ApiKeyManager')
+    def test_no_keys_raises_exception(self, mock_key_mgr):
+        """Should raise exception when no API keys are configured."""
+        mock_key_mgr.get_api_key.return_value = ''
+
+        from shortGPT.gpt.gpt_utils import llm_completion
+        with pytest.raises(Exception, match="No OpenAI, Gemini, or MiniMax API Key"):
+            llm_completion(chat_prompt="Hi", system="test")
+
+
+class TestTokenCounting:
+    """Tests for num_tokens_from_messages with non-OpenAI models."""
+
+    def test_token_count_with_unknown_model_falls_back(self):
+        """Should use cl100k_base encoding for unknown models like MiniMax."""
+        from shortGPT.gpt.gpt_utils import num_tokens_from_messages
+        # Should not raise NotImplementedError for MiniMax model
+        count = num_tokens_from_messages("Hello world", model="MiniMax-M2.7")
+        assert count > 0
+
+    def test_token_count_with_string_input(self):
+        """Should handle string input."""
+        from shortGPT.gpt.gpt_utils import num_tokens_from_messages
+        count = num_tokens_from_messages("Hello world")
+        assert count > 0
+
+    def test_token_count_with_list_input(self):
+        """Should handle list of strings input."""
+        from shortGPT.gpt.gpt_utils import num_tokens_from_messages
+        count = num_tokens_from_messages(["Hello", "world"])
+        assert count > 0
+
+
+class TestApiProviderEnum:
+    """Tests for MiniMax in ApiProvider enum."""
+
+    def test_minimax_in_api_provider(self):
+        """MINIMAX should be in the ApiProvider enum."""
+        from shortGPT.config.api_db import ApiProvider
+        assert hasattr(ApiProvider, 'MINIMAX')
+        assert ApiProvider.MINIMAX.value == 'MINIMAX_API_KEY'

--- a/tests/test_minimax_tts.py
+++ b/tests/test_minimax_tts.py
@@ -1,0 +1,169 @@
+"""Unit tests for MiniMax TTS voice module."""
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from shortGPT.audio.minimax_voice_module import (
+    MINIMAX_TTS_VOICES,
+    MiniMaxVoiceModule,
+)
+
+
+class TestMiniMaxVoiceModuleInit:
+    """Tests for MiniMaxVoiceModule initialization."""
+
+    def test_default_initialization(self):
+        """Should initialize with default parameters."""
+        module = MiniMaxVoiceModule(api_key='test-key')
+        assert module.api_key == 'test-key'
+        assert module.voice_id == 'English_Graceful_Lady'
+        assert module.model == 'speech-2.8-hd'
+        assert module.base_url == 'https://api.minimax.io'
+
+    def test_custom_voice_id(self):
+        """Should accept custom voice_id."""
+        module = MiniMaxVoiceModule(api_key='test-key', voice_id='English_Persuasive_Man')
+        assert module.voice_id == 'English_Persuasive_Man'
+
+    def test_custom_model(self):
+        """Should accept custom model."""
+        module = MiniMaxVoiceModule(api_key='test-key', model='speech-2.8-turbo')
+        assert module.model == 'speech-2.8-turbo'
+
+    def test_remaining_characters_unlimited(self):
+        """MiniMax TTS has no character limit tracking."""
+        module = MiniMaxVoiceModule(api_key='test-key')
+        assert module.get_remaining_characters() == 999999999999
+
+    def test_update_usage_returns_none(self):
+        """MiniMax TTS doesn't track usage."""
+        module = MiniMaxVoiceModule(api_key='test-key')
+        assert module.update_usage() is None
+
+
+class TestMiniMaxVoiceModuleGenerate:
+    """Tests for MiniMaxVoiceModule.generate_voice."""
+
+    @patch('shortGPT.audio.minimax_voice_module.requests.post')
+    def test_generate_voice_success(self, mock_post, tmp_path):
+        """Should generate audio file from TTS API response."""
+        # "ID3" MP3 header in hex
+        hex_audio = '494433'
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'data': {'audio': hex_audio, 'status': 2},
+            'base_resp': {'status_code': 0, 'status_msg': 'success'},
+        }
+        mock_post.return_value = mock_response
+
+        module = MiniMaxVoiceModule(api_key='test-key')
+        output_file = str(tmp_path / 'test_output.mp3')
+        result = module.generate_voice('Hello world', output_file)
+
+        assert result == output_file
+        assert os.path.exists(output_file)
+        with open(output_file, 'rb') as f:
+            content = f.read()
+        assert content == bytes.fromhex(hex_audio)
+
+    @patch('shortGPT.audio.minimax_voice_module.requests.post')
+    def test_generate_voice_sends_correct_request(self, mock_post, tmp_path):
+        """Should send correct request to MiniMax TTS API."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'data': {'audio': '494433', 'status': 2},
+            'base_resp': {'status_code': 0, 'status_msg': 'success'},
+        }
+        mock_post.return_value = mock_response
+
+        module = MiniMaxVoiceModule(api_key='test-api-key', voice_id='English_Persuasive_Man', model='speech-2.8-hd')
+        output_file = str(tmp_path / 'test.mp3')
+        module.generate_voice('Test text', output_file)
+
+        mock_post.assert_called_once()
+        call_args = mock_post.call_args
+        assert call_args[0][0] == 'https://api.minimax.io/v1/t2a_v2'
+        assert call_args[1]['headers']['Authorization'] == 'Bearer test-api-key'
+
+        payload = json.loads(call_args[1]['data'])
+        assert payload['model'] == 'speech-2.8-hd'
+        assert payload['text'] == 'Test text'
+        assert payload['stream'] is False
+        assert payload['voice_setting']['voice_id'] == 'English_Persuasive_Man'
+        assert payload['audio_setting']['format'] == 'mp3'
+
+    @patch('shortGPT.audio.minimax_voice_module.requests.post')
+    def test_generate_voice_http_error(self, mock_post):
+        """Should raise exception on HTTP error."""
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.text = 'Unauthorized'
+        mock_post.return_value = mock_response
+
+        module = MiniMaxVoiceModule(api_key='bad-key')
+        with pytest.raises(Exception, match='MiniMax TTS error: 401'):
+            module.generate_voice('Hello', '/tmp/test.mp3')
+
+    @patch('shortGPT.audio.minimax_voice_module.requests.post')
+    def test_generate_voice_api_error(self, mock_post):
+        """Should raise exception on API error response."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'data': {},
+            'base_resp': {'status_code': 1004, 'status_msg': 'Invalid API key'},
+        }
+        mock_post.return_value = mock_response
+
+        module = MiniMaxVoiceModule(api_key='bad-key')
+        with pytest.raises(Exception, match='Invalid API key'):
+            module.generate_voice('Hello', '/tmp/test.mp3')
+
+    @patch('shortGPT.audio.minimax_voice_module.requests.post')
+    def test_generate_voice_no_audio_data(self, mock_post):
+        """Should raise exception when no audio in response."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'data': {},
+            'base_resp': {'status_code': 0, 'status_msg': 'success'},
+        }
+        mock_post.return_value = mock_response
+
+        module = MiniMaxVoiceModule(api_key='test-key')
+        with pytest.raises(Exception, match='no audio data'):
+            module.generate_voice('Hello', '/tmp/test.mp3')
+
+
+class TestMiniMaxTTSVoices:
+    """Tests for MiniMax TTS voice definitions."""
+
+    def test_voice_dict_not_empty(self):
+        """Voice dictionary should have entries."""
+        assert len(MINIMAX_TTS_VOICES) > 0
+
+    def test_default_voice_exists(self):
+        """Default voice should be in the dictionary."""
+        assert 'English_Graceful_Lady' in MINIMAX_TTS_VOICES
+
+    def test_known_voices_present(self):
+        """Known valid voice IDs should be present."""
+        expected_voices = [
+            'English_Graceful_Lady',
+            'English_Insightful_Speaker',
+            'English_radiant_girl',
+            'English_Persuasive_Man',
+            'English_Lucky_Robot',
+        ]
+        for voice in expected_voices:
+            assert voice in MINIMAX_TTS_VOICES
+
+    def test_voice_module_inherits_from_abc(self):
+        """MiniMaxVoiceModule should inherit from VoiceModule ABC."""
+        from shortGPT.audio.voice_module import VoiceModule
+        assert issubclass(MiniMaxVoiceModule, VoiceModule)


### PR DESCRIPTION
## Summary
Add [MiniMax](https://platform.minimax.io/) as both an LLM and TTS provider for ShortGPT.

## Changes

### LLM Provider (Chat Model)
- Add MiniMax as alternative LLM provider in gpt_utils.py via OpenAI-compatible API
- Support MiniMax-M2.7 and MiniMax-M2.7-highspeed models (204K context window)
- Priority order: Gemini > MiniMax > OpenAI (backwards compatible)
- Temperature clamping for MiniMax API constraints (0.01-1.0)
- Fix num_tokens_from_messages() to gracefully handle non-OpenAI models

### TTS Provider (Text-to-Speech)
- Add MiniMaxVoiceModule extending VoiceModule ABC
- Support speech-2.8-hd model with 12 built-in voices
- Integrate into all 3 UI tabs: Short Automation, Video Automation, Video Translation
- Add MiniMax TTS as selectable TTS engine alongside ElevenLabs and EdgeTTS

### Configuration
- Add MINIMAX to ApiProvider enum
- Add MINIMAX_API_KEY input field in Config tab UI

### Tests
- 24 unit tests (LLM provider selection, temperature clamping, TTS module, API requests)
- 6 integration tests (LLM chat completion, streaming, TTS audio generation)

## Files Changed (13 files, 656 additions)

## API Documentation
- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api
- TTS: https://platform.minimax.io/docs/api-reference/speech-t2a-http